### PR TITLE
Remove wp- from slug

### DIFF
--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Package
               uses: actions/upload-artifact@v3
               with:
-                  name: wp-xeet
+                  name: xeet
                   retention-days: 5
                   path: |
                       ${{ github.workspace }}/

--- a/.github/workflows/release-to-wp-org.yml
+++ b/.github/workflows/release-to-wp-org.yml
@@ -28,7 +28,7 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-                  SLUG: wp-xeet
+                  SLUG: xeet
 
             - name: Upload release asset
               uses: actions/upload-release-asset@v1

--- a/.github/workflows/update-wordpress-readme.yml
+++ b/.github/workflows/update-wordpress-readme.yml
@@ -25,4 +25,4 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-                  SLUG: wp-xeet
+                  SLUG: xeet

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Embed a Xeet (or Tweet) in your WordPress post
 
 The queue for new plugins is months now, so I won't be able to submit this for review for some time. However, you can safely use it now by downloading it from this URL (click the first job, then find the artifact at the bottom), and when it's approved it will update automatically.
 
-https://github.com/KevinBatdorf/wp-xeet/actions/workflows/build-production-zip.yml
+https://github.com/KevinBatdorf/xeet-wp/actions/workflows/build-production-zip.yml
 
 ### Screenshot
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "wp-xeet",
+	"name": "xeet",
 	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "wp-xeet",
+			"name": "xeet",
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-xeet",
+	"name": "xeet",
 	"version": "0.1.0",
 	"description": "My amazing block",
 	"author": "Kevin Batdorf",

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WP Xeet ===
+=== Xeet ===
 Contributors:      kbat82
 Tags:              block, tweet, twitter, x, xeet, embed
 Tested up to:      6.3

--- a/src/block.json
+++ b/src/block.json
@@ -1,9 +1,9 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "kevinbatdorf/wp-xeet",
+	"name": "kevinbatdorf/xeet",
 	"version": "0.1.0",
-	"title": "WP Xeet",
+	"title": "Xeet",
 	"category": "embed",
 	"description": "Embed a Tweet/Xeet without an iframe (and save 500kb page load)",
 	"attributes": {
@@ -20,7 +20,7 @@
 	"supports": {
 		"html": false
 	},
-	"textdomain": "wp-xeet",
+	"textdomain": "xeet",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css",

--- a/src/editor/NoTweet.tsx
+++ b/src/editor/NoTweet.tsx
@@ -10,18 +10,18 @@ type NoTweetProps = {
 };
 export const NoTweet = ({ attributes, setAttributes }: NoTweetProps) => {
 	return (
-		<div className="wp-xeet-editor">
+		<div className="xeet-editor">
 			<Placeholder
 				icon={xIcon}
 				label={'Share a Xeet'}
 				instructions={__(
 					'Paste a link to the Xeet URL you want to display on your site.',
-					'wp-xeet',
+					'xeet',
 				)}>
 				<TextControl
 					__nextHasNoMarginBottom
-					label={__('Xeet (or Tweet) ID', 'wp-xeet')}
-					placeholder={__('Enter URL to embed here...', 'wp-xeet')}
+					label={__('Xeet (or Tweet) ID', 'xeet')}
+					placeholder={__('Enter URL to embed here...', 'xeet')}
 					className="w-full"
 					onChange={(maybeId) => {
 						const xeetId = extractTwitterId(maybeId);

--- a/src/editor/Settings.tsx
+++ b/src/editor/Settings.tsx
@@ -67,16 +67,13 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody initialOpen={false} title={__('Settings', 'wp-xeet')}>
+			<PanelBody initialOpen={false} title={__('Settings', 'xeet')}>
 				<BaseControl id="xeet-settings">
-					<div className="wp-xeet-editor">
+					<div className="xeet-editor">
 						<TextControl
-							label={__('Xeet ID', 'wp-xeet')}
+							label={__('Xeet ID', 'xeet')}
 							className={error ? 'text-red-500' : undefined}
-							help={__(
-								'Paste a Xeet/Tweet URL or ID.',
-								'wp-xeet',
-							)}
+							help={__('Paste a Xeet/Tweet URL or ID.', 'xeet')}
 							value={attributes.xeetId ?? ''}
 							onChange={(maybeId) => {
 								setAttributes({ xeetData: undefined });
@@ -87,40 +84,38 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 						/>
 						{isError && (
 							<p className="text-red-500">
-								{__('Error loading tweet.', 'wp-xeet')}
+								{__('Error loading tweet.', 'xeet')}
 							</p>
 						)}
 						{showUpdateButton && (
 							<>
-								<p>{__('Data change detected.', 'wp-xeet')}</p>
+								<p>{__('Data change detected.', 'xeet')}</p>
 								<Button
 									variant="secondary"
 									onClick={() => {
 										const xeetData = enrichTweet(data);
 										updateXeet(xeetData);
 									}}>
-									{__('Update data', 'wp-xeet')}
+									{__('Update data', 'xeet')}
 								</Button>
 							</>
 						)}
 					</div>
 				</BaseControl>
 			</PanelBody>
-			<PanelBody
-				title={__('Theme Override', 'wp-xeet')}
-				initialOpen={false}>
+			<PanelBody title={__('Theme Override', 'xeet')} initialOpen={false}>
 				<BaseControl id="xeet-theme">
-					<div className="wp-xeet-editor">
+					<div className="xeet-editor">
 						<SelectControl
-							label={__('Theme', 'wp-xeet')}
+							label={__('Theme', 'xeet')}
 							value={attributes.theme}
 							options={[
-								{ label: __('Auto', 'wp-xeet'), value: 'auto' },
+								{ label: __('Auto', 'xeet'), value: 'auto' },
 								{
-									label: __('Light', 'wp-xeet'),
+									label: __('Light', 'xeet'),
 									value: 'light',
 								},
-								{ label: __('Dark', 'wp-xeet'), value: 'dark' },
+								{ label: __('Dark', 'xeet'), value: 'dark' },
 							]}
 							onChange={(theme) => {
 								if (theme === 'auto') {
@@ -134,7 +129,7 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 						<p className="bg-gray-200 p-3">
 							{__(
 								"By default, the Xeet block will detect the user's system preferences and apply a light or dark theme. See plugin readme for more info on how to override this.",
-								'wp-xeet',
+								'xeet',
 							)}
 						</p>
 					</div>

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -1,4 +1,4 @@
-:where(.wp-xeet-editor) {
+:where(.xeet-editor) {
 	--tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
 	--tw-ring-offset-width: 0px;
 	--tw-ring-offset-color: transparent;
@@ -11,9 +11,9 @@
 	--tw-scale-x: 1;
 	--tw-scale-y: 1;
 }
-:where(.wp-xeet-editor) *,
-:where(.wp-xeet-editor) *:after,
-:where(.wp-xeet-editor) *:before {
+:where(.xeet-editor) *,
+:where(.xeet-editor) *:after,
+:where(.xeet-editor) *:before {
 	/* no !important */
 	box-sizing: border-box;
 	border: 0 solid #e5e7eb;

--- a/src/front/front.js
+++ b/src/front/front.js
@@ -1,6 +1,6 @@
 import copy from 'copy-to-clipboard';
 
-const xeet = '.wp-xeet';
+const xeet = '.xeet';
 const copyUrlButtonClass = '[data-xeet-url-to-copy]:not(.xeet-copy-added)';
 const handleCopyButton = () => {
 	document.querySelectorAll(copyUrlButtonClass).forEach((el) => {
@@ -36,27 +36,25 @@ const handleCopyButton = () => {
 };
 const handlePlayButton = () => {
 	const xeetPlay = document.querySelectorAll(
-		`${xeet} .wp-xeet-video-button:not(.xeet-play-added)`,
+		`${xeet} .xeet-video-button:not(.xeet-play-added)`,
 	);
 	const onPlay = (e) => {
 		e.preventDefault();
 		const video = e.target;
-		video
-			.closest('.wp-xeet-video-container')
-			.classList.add('xeet-is-playing');
+		video.closest('.xeet-video-container').classList.add('xeet-is-playing');
 		video.controls = true;
 		video.addEventListener('pause', onPause);
 		video.addEventListener('ended', onEnded);
 		// Update "watch on" button text
 		const wo = '[data-continue-watching-text]';
 		const watchOn = video
-			.closest('.wp-xeet-video-container')
+			.closest('.xeet-video-container')
 			.querySelector(wo);
 		if (watchOn) {
 			watchOn.textContent = watchOn.dataset.continueWatchingText;
 		}
 		video
-			.closest('.wp-xeet-video-container')
+			.closest('.xeet-video-container')
 			.classList.remove('xeet-is-finished');
 	};
 	const onPause = (e) => {
@@ -64,7 +62,7 @@ const handlePlayButton = () => {
 		e.preventDefault();
 		const video = e.target;
 		video
-			.closest('.wp-xeet-video-container')
+			.closest('.xeet-video-container')
 			.classList.remove('xeet-is-playing');
 		video.removeEventListener('pause', onPause);
 	};
@@ -73,7 +71,7 @@ const handlePlayButton = () => {
 		e.preventDefault();
 		const video = e.target;
 		video
-			.closest('.wp-xeet-video-container')
+			.closest('.xeet-video-container')
 			.classList.add('xeet-is-finished');
 		video.removeEventListener('ended', onEnded);
 	};
@@ -82,7 +80,7 @@ const handlePlayButton = () => {
 		el.addEventListener('click', (e) => {
 			e.preventDefault();
 			const video = el
-				.closest('.wp-xeet-video-container')
+				.closest('.xeet-video-container')
 				.querySelector('video');
 
 			el.remove();

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -129,6 +129,6 @@
 .xeet-is-playing .xeet-watch-link {
 	display: none;
 }
-.wp-xeet-video-container:not(.xeet-is-finished) .xeet-view-replies {
+.xeet-video-container:not(.xeet-is-finished) .xeet-view-replies {
 	display: none;
 }

--- a/src/front/vercel/TweetActions.tsx
+++ b/src/front/vercel/TweetActions.tsx
@@ -14,7 +14,7 @@ export const TweetActions = ({ tweet }: { tweet: EnrichedTweet }) => {
 				target="_blank"
 				rel="noopener noreferrer"
 				aria-label={sprintf(
-					__('Like. This Tweet has %s likes', 'wp-xeet'),
+					__('Like. This Tweet has %s likes', 'xeet'),
 					favoriteCount,
 				)}>
 				<div className={s.likeIconWrapper}>
@@ -34,7 +34,7 @@ export const TweetActions = ({ tweet }: { tweet: EnrichedTweet }) => {
 				href={tweet.reply_url}
 				target="_blank"
 				rel="noopener noreferrer"
-				aria-label={__('Reply to this Tweet on Twitter', 'wp-xeet')}>
+				aria-label={__('Reply to this Tweet on Twitter', 'xeet')}>
 				<div className={s.replyIconWrapper}>
 					<svg
 						viewBox="0 0 24 24"

--- a/src/front/vercel/TweetActionsCopy.tsx
+++ b/src/front/vercel/TweetActionsCopy.tsx
@@ -7,7 +7,7 @@ export const TweetActionsCopy = ({ tweet }: { tweet: EnrichedTweet }) => {
 		<button
 			type="button"
 			className={s.copy}
-			aria-label={__('Copy link', 'wp-xeet')}
+			aria-label={__('Copy link', 'xeet')}
 			data-xeet-url-to-copy={tweet.url}>
 			<div className={s.copyIconWrapper}>
 				<svg
@@ -31,10 +31,10 @@ export const TweetActionsCopy = ({ tweet }: { tweet: EnrichedTweet }) => {
 			<span
 				className={s.copyText}
 				data-copy-text={JSON.stringify({
-					copied: __('Copied!', 'wp-xeet'),
-					copyAllText: __('Copy link to Tweet', 'wp-xeet'),
+					copied: __('Copied!', 'xeet'),
+					copyAllText: __('Copy link to Tweet', 'xeet'),
 				})}>
-				{__('Copy link', 'wp-xeet')}
+				{__('Copy link', 'xeet')}
 			</span>
 		</button>
 	);

--- a/src/front/vercel/TweetInfo.tsx
+++ b/src/front/vercel/TweetInfo.tsx
@@ -13,7 +13,7 @@ export const TweetInfo = ({ tweet }: { tweet: EnrichedTweet }) => (
 			rel="noopener noreferrer"
 			aria-label={__(
 				'Twitter for Websites, Ads Information and Privacy',
-				'wp-xeet',
+				'xeet',
 			)}>
 			<svg viewBox="0 0 24 24" aria-hidden="true" className={s.infoIcon}>
 				<g>

--- a/src/front/vercel/TweetMedia.tsx
+++ b/src/front/vercel/TweetMedia.tsx
@@ -72,7 +72,7 @@ export const TweetMedia = ({ tweet, components, quoted }: Props) => {
 								className={
 									s.mediaContainer +
 									' ' +
-									'wp-xeet-video-container'
+									'xeet-video-container'
 								}>
 								<div
 									className={s.skeleton}

--- a/src/front/vercel/TweetMediaVideo.tsx
+++ b/src/front/vercel/TweetMediaVideo.tsx
@@ -40,8 +40,8 @@ export const TweetMediaVideo = ({ tweet, media }: Props) => {
 
 			<button
 				type="button"
-				className={s.videoButton + ' ' + 'wp-xeet-video-button'}
-				aria-label={__('View video on Twitter', 'wp-xeet')}
+				className={s.videoButton + ' ' + 'xeet-video-button'}
+				aria-label={__('View video on Twitter', 'xeet')}
 				onClick={() => undefined}>
 				<svg
 					viewBox="0 0 24 24"
@@ -60,10 +60,10 @@ export const TweetMediaVideo = ({ tweet, media }: Props) => {
 					target="_blank"
 					data-continue-watching-text={__(
 						'Continue watching on Twitter',
-						'wp-xeet',
+						'xeet',
 					)}
 					rel="noopener noreferrer">
-					{__('Watch on Twitter', 'wp-xeet')}
+					{__('Watch on Twitter', 'xeet')}
 				</a>
 			</div>
 
@@ -76,7 +76,7 @@ export const TweetMediaVideo = ({ tweet, media }: Props) => {
 				// alow for unlimited loop
 				target="_blank"
 				rel="noopener noreferrer">
-				{__('View replies', 'wp-xeet')}
+				{__('View replies', 'xeet')}
 			</a>
 		</>
 	);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ export type Attributes = {
 	theme?: 'light' | 'dark';
 };
 
-registerBlockType<Attributes>('kevinbatdorf/wp-xeet', {
+registerBlockType<Attributes>('kevinbatdorf/xeet', {
 	...blockConfig,
 	icon: xIcon,
 	attributes: {
@@ -22,7 +22,7 @@ registerBlockType<Attributes>('kevinbatdorf/wp-xeet', {
 		xeetData: { type: 'object' },
 		theme: { type: 'string', default: undefined },
 	},
-	title: __('WP Xeet', 'wp-xeet'),
+	title: __('Xeet', 'xeet'),
 	edit: ({ attributes, setAttributes }) => {
 		const { xeetData, theme } = attributes;
 		return (
@@ -32,7 +32,7 @@ registerBlockType<Attributes>('kevinbatdorf/wp-xeet', {
 					setAttributes={setAttributes}
 				/>
 				<div
-					{...blockProps({ className: 'wp-xeet-editor wp-xeet' })}
+					{...blockProps({ className: 'xeet-editor xeet' })}
 					data-theme={theme}>
 					{xeetData ? null : (
 						<NoTweet
@@ -52,7 +52,7 @@ registerBlockType<Attributes>('kevinbatdorf/wp-xeet', {
 		return (
 			<div
 				{...blockProps.save({
-					className: 'wp-xeet',
+					className: 'xeet',
 				})}
 				data-theme={theme}>
 				{xeetData && <Xeet xeet={xeetData} />}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ delete colors['blueGray'];
 
 // See postcss.config.js for more parsing options.
 module.exports = {
-	important: '.wp-xeet',
+	important: '.xeet',
 	content: ['./src/**/*.{ts,tsx}'],
 	theme: {
 		screens: {

--- a/xeet.php
+++ b/xeet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       WP Xeet
+ * Plugin Name:       Xeet
  * Description:       Embed a Tweet/Xeet without an iframe
  * Requires at least: 5.8
  * Requires PHP:      7.0
@@ -8,13 +8,13 @@
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       wp-xeet
+ * Text Domain:       xeet
  *
  * @package           kevinbatdorf
  */
 
 add_action('init', function () {
     register_block_type(__DIR__ . '/build');
-    wp_set_script_translations('kevinbatdorf/wp-xeet', 'wp-xeet');
-	wp_add_inline_style('kevinbatdorf-wp-xeet-style', file_get_contents(__DIR__ . '/build/xeet.css'));
+    wp_set_script_translations('kevinbatdorf/xeet', 'xeet');
+	wp_add_inline_style('kevinbatdorf-xeet-style', file_get_contents(__DIR__ . '/build/xeet.css'));
 });


### PR DESCRIPTION
WP won't accept a wp- prefix so even though I said I wouldn't change it, here we are. Not sure another way around it than to just rip off the bandaid. It just means if you are using the plugin today, and tomorrow it gets added to w.org you won't see that there is an update. Shouldn't affect anything else though