### PR TITLE
Add render tests for tweet embedding

### DIFF
--- a/tests/xeet-render.spec.ts
+++ b/tests/xeet-render.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+
+test.beforeEach(async ({ requestUtils }) => {
+	await requestUtils.login();
+});
+
+test('Renders a tweet when a valid URL is pasted', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	await admin.createNewPost({ title: 'Render test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	// Type a tweet URL into the placeholder input
+	const input = page.getByPlaceholder('Enter URL to embed here...');
+	await input.fill('https://x.com/jack/status/20');
+
+	// Wait for the tweet to render — the NoTweet placeholder disappears
+	// and the xeet data renders inside the block
+	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	await expect(block.locator('.react-tweet-theme')).toBeVisible({
+		timeout: 30000,
+	});
+
+	// Verify tweet text content is present
+	await expect(block.getByText('just setting up my twttr')).toBeVisible();
+});
+
+test('Shows placeholder when block is inserted without a tweet', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	await admin.createNewPost({ title: 'Empty test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	await expect(
+		page.getByLabel('Block: Xeet').getByText('Paste a link to the Xeet URL'),
+	).toBeVisible();
+});
+
+test('Invalid input does not clear the field', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	await admin.createNewPost({ title: 'Invalid input test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	const input = page.getByPlaceholder('Enter URL to embed here...');
+	await input.fill('not-a-valid-url');
+
+	// Field should still have the typed value
+	await expect(input).toHaveValue('not-a-valid-url');
+
+	// Block should still show the placeholder, not a tweet
+	await expect(
+		page.getByLabel('Block: Xeet').getByText('Paste a link to the Xeet URL'),
+	).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Adds tests that verify a tweet actually renders after pasting a valid URL (Jack's first tweet)
- Tests that the placeholder shows on empty block insertion
- Tests that invalid input doesn't clear the field (validates the input fix from #26)

## Test plan
- [ ] CI passes all 4 tests (1 existing + 3 new)
- [ ] Render test fetches live tweet data from Vercel API

🤖 Generated with [Claude Code](https://claude.com/claude-code)