### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              block, tweet, twitter, social, embed
 Tested up to:      7.0
-Stable tag:        1.0.2
+Stable tag:        1.0.3
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/xeet.php
+++ b/xeet.php
@@ -4,7 +4,7 @@
  * Description:       Embed a Tweet/Xeet without an iframe
  * Requires at least: 5.8
  * Requires PHP:      7.0
- * Version:           1.0.2
+ * Version:           1.0.3
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- Bump plugin version to 1.0.3 to trigger WP.org deploy with clean SVN state

🤖 Generated with [Claude Code](https://claude.com/claude-code)