### PR TITLE
Fix block crash: TypeError: r is not iterable due to missing tweet entities

### DIFF
--- a/src/editor/Settings.tsx
+++ b/src/editor/Settings.tsx
@@ -11,8 +11,8 @@ import type { Attributes } from '..';
 import './editor.css';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import type { EnrichedTweet } from 'react-tweet';
-import { enrichTweet, useTweet } from 'react-tweet';
-import { extractTwitterId } from '../util';
+import { useTweet } from 'react-tweet';
+import { extractTwitterId, safeEnrichTweet } from '../util';
 
 interface ControlProps {
 	attributes: Attributes;
@@ -46,7 +46,7 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 		setIsError(false);
 
 		// If the xeet has not yet been set, set it.
-		const xeetData = enrichTweet(data);
+		const xeetData = safeEnrichTweet(data);
 		if (!attributes.xeetData) return updateXeet(xeetData);
 
 		// if the id doesn't match ours, update the xeet
@@ -98,7 +98,7 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 								<Button
 									variant="secondary"
 									onClick={() => {
-										const xeetData = enrichTweet(data);
+										const xeetData = safeEnrichTweet(data);
 										updateXeet(xeetData);
 									}}
 								>

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,2 +1,34 @@
+import { enrichTweet } from 'react-tweet';
+
 export const extractTwitterId = (input: string) =>
 	/^\d+$/.test(input) ? input : (input.match(/\/status\/(\d+)/) || [])[1];
+
+export const safeEnrichTweet = (tweet: any): any => {
+	if (!tweet) return tweet;
+	const safeTweet = { ...tweet };
+	if (typeof safeTweet.text !== 'string') {
+		safeTweet.text = safeTweet.text || '';
+	}
+	if (!Array.isArray(safeTweet.display_text_range)) {
+		safeTweet.display_text_range = [0, safeTweet.text.length];
+	}
+	if (!safeTweet.entities) {
+		safeTweet.entities = {};
+	} else {
+		safeTweet.entities = { ...safeTweet.entities };
+	}
+	const entities = safeTweet.entities;
+	if (!Array.isArray(entities.hashtags)) entities.hashtags = [];
+	if (!Array.isArray(entities.user_mentions)) entities.user_mentions = [];
+	if (!Array.isArray(entities.urls)) entities.urls = [];
+	if (!Array.isArray(entities.symbols)) entities.symbols = [];
+	if (entities.media && !Array.isArray(entities.media)) {
+		entities.media = [];
+	}
+
+	if (safeTweet.quoted_tweet) {
+		safeTweet.quoted_tweet = safeEnrichTweet(safeTweet.quoted_tweet);
+	}
+	return enrichTweet(safeTweet);
+};
+


### PR DESCRIPTION
### Describe the Bug
The editor block crashes with the error **"This block has encountered an error and cannot be previewed."** when rendering a tweet that has incomplete or missing entity fields (e.g., if the tweet has no hashtags and `entities.hashtags` is omitted from the API response).

In the browser console, the following stack trace is displayed:
```
TypeError: r is not iterable
    at ke (index.js:1:14440)  // addEntities()
    at be (index.js:1:13486)  // getEntities()
    at Ne (index.js:1:14928)  // enrichTweet()
```

### Cause
The crash occurs inside `react-tweet`'s internal `getEntities` utility. When a tweet is processed by `enrichTweet(data)`, the library expects `tweet.entities` to always contain the `hashtags`, `user_mentions`, `urls`, and `symbols` properties:
```javascript
addEntities(result, 'hashtag', tweet.entities.hashtags);
addEntities(result, 'mention', tweet.entities.user_mentions);
addEntities(result, 'url', tweet.entities.urls);
addEntities(result, 'symbol', tweet.entities.symbols);
```
If the Twitter API or local cached/stored data omits any of these array properties (making them `undefined`), `addEntities` tries to run a `for...of` loop over `undefined`, causing the `TypeError` and crashing the Gutenberg block.

### Proposed Solution
Before passing the fetched tweet object to `react-tweet`'s `enrichTweet()`, sanitize it recursively (including any nested `quoted_tweet`) to guarantee that `text` is a string, `display_text_range` is defined, and `entities` includes default empty arrays for all expected entity types:

```typescript
export const safeEnrichTweet = (tweet: any): any => {
	if (!tweet) return tweet;
	const safeTweet = { ...tweet };
	if (typeof safeTweet.text !== 'string') {
		safeTweet.text = safeTweet.text || '';
	}
	if (!Array.isArray(safeTweet.display_text_range)) {
		safeTweet.display_text_range = [0, safeTweet.text.length];
	}
	if (!safeTweet.entities) {
		safeTweet.entities = {};
	} else {
		safeTweet.entities = { ...safeTweet.entities };
	}
	const entities = safeTweet.entities;
	if (!Array.isArray(entities.hashtags)) entities.hashtags = [];
	if (!Array.isArray(entities.user_mentions)) entities.user_mentions = [];
	if (!Array.isArray(entities.urls)) entities.urls = [];
	if (!Array.isArray(entities.symbols)) entities.symbols = [];
	if (entities.media && !Array.isArray(entities.media)) {
		entities.media = [];
	}

	if (safeTweet.quoted_tweet) {
		safeTweet.quoted_tweet = safeEnrichTweet(safeTweet.quoted_tweet);
	}
	return enrichTweet(safeTweet);
};
```
Replacing `enrichTweet(data)` with `safeEnrichTweet(data)` resolves the issue and prevents editor block crashes.
