### PR TITLE
Add failing test for missing tweet entity arrays

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -52,7 +52,7 @@ jobs:
       run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: pw-cache
       with:
         path: ~/.cache/ms-playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,7 +51,7 @@ jobs:
       run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: pw-cache
       with:
         path: ~/.cache/ms-playwright

--- a/src/editor/Settings.tsx
+++ b/src/editor/Settings.tsx
@@ -11,8 +11,8 @@ import type { Attributes } from '..';
 import './editor.css';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import type { EnrichedTweet } from 'react-tweet';
-import { enrichTweet, useTweet } from 'react-tweet';
-import { extractTwitterId } from '../util';
+import { useTweet } from 'react-tweet';
+import { extractTwitterId, safeEnrichTweet } from '../util';
 
 interface ControlProps {
 	attributes: Attributes;
@@ -46,7 +46,7 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 		setIsError(false);
 
 		// If the xeet has not yet been set, set it.
-		const xeetData = enrichTweet(data);
+		const xeetData = safeEnrichTweet(data);
 		if (!attributes.xeetData) return updateXeet(xeetData);
 
 		// if the id doesn't match ours, update the xeet
@@ -98,7 +98,7 @@ export const Settings = ({ attributes, setAttributes }: ControlProps) => {
 								<Button
 									variant="secondary"
 									onClick={() => {
-										const xeetData = enrichTweet(data);
+										const xeetData = safeEnrichTweet(data);
 										updateXeet(xeetData);
 									}}
 								>

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,34 +1,30 @@
 import { enrichTweet } from 'react-tweet';
+import type { EnrichedTweet } from 'react-tweet';
+
+type Tweet = Parameters<typeof enrichTweet>[0];
+type TweetEntities = Tweet['entities'];
 
 export const extractTwitterId = (input: string) =>
 	/^\d+$/.test(input) ? input : (input.match(/\/status\/(\d+)/) || [])[1];
 
-export const safeEnrichTweet = (tweet: any): any => {
-	if (!tweet) return tweet;
-	const safeTweet = { ...tweet };
-	if (typeof safeTweet.text !== 'string') {
-		safeTweet.text = safeTweet.text || '';
-	}
-	if (!Array.isArray(safeTweet.display_text_range)) {
-		safeTweet.display_text_range = [0, safeTweet.text.length];
-	}
-	if (!safeTweet.entities) {
-		safeTweet.entities = {};
-	} else {
-		safeTweet.entities = { ...safeTweet.entities };
-	}
-	const entities = safeTweet.entities;
-	if (!Array.isArray(entities.hashtags)) entities.hashtags = [];
-	if (!Array.isArray(entities.user_mentions)) entities.user_mentions = [];
-	if (!Array.isArray(entities.urls)) entities.urls = [];
-	if (!Array.isArray(entities.symbols)) entities.symbols = [];
-	if (entities.media && !Array.isArray(entities.media)) {
-		entities.media = [];
-	}
+const sanitizeEntities = (
+	entities: Partial<TweetEntities> | null | undefined,
+): TweetEntities => ({
+	hashtags: entities?.hashtags ?? [],
+	urls: entities?.urls ?? [],
+	user_mentions: entities?.user_mentions ?? [],
+	symbols: entities?.symbols ?? [],
+	...(entities?.media?.length && { media: entities.media }),
+});
 
-	if (safeTweet.quoted_tweet) {
-		safeTweet.quoted_tweet = safeEnrichTweet(safeTweet.quoted_tweet);
-	}
-	return enrichTweet(safeTweet);
-};
-
+export const safeEnrichTweet = (tweet: Tweet): EnrichedTweet =>
+	enrichTweet({
+		...tweet,
+		entities: sanitizeEntities(tweet.entities),
+		...(tweet.quoted_tweet && {
+			quoted_tweet: {
+				...tweet.quoted_tweet,
+				entities: sanitizeEntities(tweet.quoted_tweet.entities),
+			},
+		}),
+	});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,2 +1,34 @@
+import { enrichTweet } from 'react-tweet';
+
 export const extractTwitterId = (input: string) =>
 	/^\d+$/.test(input) ? input : (input.match(/\/status\/(\d+)/) || [])[1];
+
+export const safeEnrichTweet = (tweet: any): any => {
+	if (!tweet) return tweet;
+	const safeTweet = { ...tweet };
+	if (typeof safeTweet.text !== 'string') {
+		safeTweet.text = safeTweet.text || '';
+	}
+	if (!Array.isArray(safeTweet.display_text_range)) {
+		safeTweet.display_text_range = [0, safeTweet.text.length];
+	}
+	if (!safeTweet.entities) {
+		safeTweet.entities = {};
+	} else {
+		safeTweet.entities = { ...safeTweet.entities };
+	}
+	const entities = safeTweet.entities;
+	if (!Array.isArray(entities.hashtags)) entities.hashtags = [];
+	if (!Array.isArray(entities.user_mentions)) entities.user_mentions = [];
+	if (!Array.isArray(entities.urls)) entities.urls = [];
+	if (!Array.isArray(entities.symbols)) entities.symbols = [];
+	if (entities.media && !Array.isArray(entities.media)) {
+		entities.media = [];
+	}
+
+	if (safeTweet.quoted_tweet) {
+		safeTweet.quoted_tweet = safeEnrichTweet(safeTweet.quoted_tweet);
+	}
+	return enrichTweet(safeTweet);
+};
+

--- a/tests/xeet-render.spec.ts
+++ b/tests/xeet-render.spec.ts
@@ -74,6 +74,46 @@ test('Block handles missing tweet entity fields without crashing', async ({
 	});
 });
 
+test('Block renders a tweet that contains a quoted tweet', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	await page.route('**/react-tweet.vercel.app/**', async (route) => {
+		const response = await route.fetch();
+		const body = await response.json();
+		if (body?.data) {
+			body.data.quoted_tweet = {
+				...body.data,
+				id_str: '999',
+				text: 'this is the quoted tweet',
+				entities: {
+					hashtags: [],
+					user_mentions: [],
+					urls: [],
+					symbols: [],
+				},
+			};
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(body),
+		});
+	});
+
+	await admin.createNewPost({ title: 'Quoted tweet test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	const input = page.getByPlaceholder('Enter URL to embed here...');
+	await input.fill('https://x.com/jack/status/20');
+
+	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	await expect(block.locator('.react-tweet-theme')).toBeVisible({
+		timeout: 15000,
+	});
+});
+
 test('Invalid input does not clear the field', async ({
 	admin,
 	page,

--- a/tests/xeet-render.spec.ts
+++ b/tests/xeet-render.spec.ts
@@ -114,6 +114,39 @@ test('Block renders a tweet that contains a quoted tweet', async ({
 	});
 });
 
+test('Block renders a tweet with an empty media array without crashing', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	// Bug: safeEnrichTweet setting entities.media = [] causes fixRange inside
+	// enrichTweet to crash — it checks `if (tweet.entities.media)` which passes
+	// for a truthy empty array, then accesses media[0].indices on undefined.
+	await page.route('**/react-tweet.vercel.app/**', async (route) => {
+		const response = await route.fetch();
+		const body = await response.json();
+		if (body?.data?.entities) {
+			body.data.entities = { ...body.data.entities, media: [] };
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(body),
+		});
+	});
+
+	await admin.createNewPost({ title: 'Empty media test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	const input = page.getByPlaceholder('Enter URL to embed here...');
+	await input.fill('https://x.com/jack/status/20');
+
+	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	await expect(block.locator('.react-tweet-theme')).toBeVisible({
+		timeout: 15000,
+	});
+});
+
 test('Invalid input does not clear the field', async ({
 	admin,
 	page,

--- a/tests/xeet-render.spec.ts
+++ b/tests/xeet-render.spec.ts
@@ -40,6 +40,40 @@ test('Shows placeholder when block is inserted without a tweet', async ({
 	).toBeVisible();
 });
 
+test('Block handles missing tweet entity fields without crashing', async ({
+	admin,
+	page,
+	editor,
+}) => {
+	// Simulate the bug from PR #30: tweet data where entities arrays are absent.
+	// enrichTweet() iterates over tweet.entities.hashtags etc. with for...of,
+	// throwing "TypeError: r is not iterable" when they are undefined.
+	// Fetch the real tweet then strip entity arrays so the data shape is valid.
+	await page.route('**/react-tweet.vercel.app/**', async (route) => {
+		const response = await route.fetch();
+		const body = await response.json();
+		if (body?.data?.entities) {
+			body.data.entities = {};
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(body),
+		});
+	});
+
+	await admin.createNewPost({ title: 'Missing entities test' });
+	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
+
+	const input = page.getByPlaceholder('Enter URL to embed here...');
+	await input.fill('https://x.com/jack/status/20');
+
+	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	await expect(block.locator('.react-tweet-theme')).toBeVisible({
+		timeout: 15000,
+	});
+});
+
 test('Invalid input does not clear the field', async ({
 	admin,
 	page,


### PR DESCRIPTION
## Summary
- Adds a test that reproduces the `TypeError: r is not iterable` crash from PR #30
- Intercepts the tweet API and strips entity arrays to trigger the bug
- This test is **red on main** and **green once PR #30 is merged**

Closes / validates #30