### PR TITLE
Add release and pr lifecycle skills

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pr
+description: Manage the PR lifecycle — open, check CI, and merge pull requests. Use when the user wants to open a PR, check whether a PR's CI passed, see if a PR is ready, or merge a PR. Covers the open/check/merge flow with the guardrails that the work goes on a branch and CI is green before merging. Not for code review (that's a separate task).
+---
+
+# PR lifecycle
+
+Open, check, and merge PRs with `gh`. The recurring mistakes this prevents:
+working on `main`, and merging before CI is confirmed green.
+
+## Open a PR
+
+1. **Branch first.** Never commit on `main`. If there are uncommitted changes on
+   `main`, `git checkout -b <branch>` before committing. See [[branch-before-changes]].
+   Pick a branch name that matches the *scope* of the work, not one narrow file —
+   if it may grow, name it broader (`add/skills`, not `add/release-skill`).
+2. Commit, push with `-u`, then `gh pr create` with a title and a body that
+   summarizes what changed and why.
+3. Link related PRs/issues by number in the body.
+
+## Check a PR
+
+- `gh pr view <number>` — state (open/merged/closed), title, body, comments.
+  **Read existing comments** before adding your own so you don't repeat the thread.
+- `gh pr checks <number>` — one-shot status. Add `--watch` to block until checks
+  finish.
+- For a failing check, pull the log: `gh run view <run-id> --job <job-id> --log`
+  and grep for the failure.
+
+## Merge a PR
+
+Do all three verifications, in order, every time:
+
+1. `gh pr view <number>` — confirm it is still **OPEN**. Don't assume; it may
+   already be merged or closed.
+2. `gh pr checks <number>` — every check **passed**. Never merge on red or pending.
+3. `gh pr merge <number> --squash` (default to squash unless told otherwise).
+
+If anything is red or pending, stop and report — do not merge.
+
+## Guardrails
+
+- Branch → PR → merge. Nothing committed directly to `main`.
+- PR confirmed open + all CI green before merge — no exceptions.
+- If a merge triggers a downstream deploy (e.g. a release workflow), confirm with
+  the user first. For full releases use the [[release]] skill.
+- Working in small, reported steps beats long silent runs — surface CI status and
+  outcomes as you go.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -33,6 +33,33 @@ A mismatch ships a broken release to WP.org. Always update both.
   ```
   Use today's date. Describe changes in user-facing terms, not implementation.
 
+### 2b. Update "Tested up to" against the latest WordPress beta/RC
+
+`readme.txt` has `Tested up to:        X.Y`. This should reflect the newest
+WordPress version we've actually run our tests against — the upcoming
+**beta/RC** if a release cycle is in flight, otherwise the latest stable.
+**Never use an alpha/nightly** for this — alpha is unstable trunk, not a real
+target.
+
+1. Find the latest stable and the current development version:
+   ```sh
+   curl -s "https://api.wordpress.org/core/version-check/1.7/?channel=development" \
+     | python3 -c "import sys,json; d=json.load(sys.stdin); o={x['response']:x['current'] for x in d['offers']}; print('stable:', o.get('latest')); print('dev:', o.get('development'))"
+   ```
+2. Decide the target version:
+   - If `dev` contains `beta` or `RC` (e.g. `6.9-RC1`) → a cycle is active. Target
+     is that version's major.minor (e.g. `6.9`).
+   - If `dev` contains `alpha` (e.g. `7.1-alpha-62472`) → no beta yet. Target is
+     the latest **stable** major.minor (e.g. `7.0`). Leave "Tested up to" there.
+3. If the target is a beta/RC, run the suite against it before claiming support:
+   ```sh
+   WP_VERSION=<beta-version> npm run test:e2e
+   ```
+   (`playwright.config.ts` and `scripts/run-e2e.mjs` both read `WP_VERSION`;
+   default is `latest`.) Tests must pass against that version.
+4. Set `Tested up to:` to the target major.minor (e.g. `6.9` or `7.0`) — the
+   WordPress.org readme expects `X.Y`, not a beta suffix.
+
 ### 3. Open the release PR
 - Commit (`Bump version to X.Y.Z`), push, `gh pr create`.
 - Body should list the changelog entries.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: release
+description: Prepare and publish a new wp-xeet release. Use when the user wants to cut a release, bump the version, or ship a fix to WordPress.org. Bumps the version in both required files, updates the changelog, opens a release PR, and (after confirmation) tags the release to trigger the WP.org deploy.
+---
+
+# Releasing wp-xeet
+
+A release tag triggers a **production deploy to WordPress.org** via
+`release-to-wp-org.yml` (`on: release: published`). Treat the tag as the point
+of no return — everything before it is reversible, the tag is not.
+
+## Version lives in two files — both must match
+
+- `xeet.php` → `* Version:           X.Y.Z`
+- `readme.txt` → `Stable tag:        X.Y.Z`
+
+A mismatch ships a broken release to WP.org. Always update both.
+
+## Steps
+
+### 1. Confirm what's shipping
+- `git checkout main && git pull`
+- Confirm the fix/feature being released is already merged to main (`git log --oneline -10`).
+- Pick the new version. Patch (Z) for fixes, minor (Y) for features. Ask the user if unclear.
+
+### 2. Branch + bump
+- `git checkout -b release/X.Y.Z`
+- Edit `xeet.php` Version and `readme.txt` Stable tag to `X.Y.Z`.
+- Add a changelog entry to `readme.txt` under `== Changelog ==`, newest first:
+  ```
+  = X.Y.Z - YYYY-MM-DD =
+  - <user-facing description of each change>
+  ```
+  Use today's date. Describe changes in user-facing terms, not implementation.
+
+### 3. Open the release PR
+- Commit (`Bump version to X.Y.Z`), push, `gh pr create`.
+- Body should list the changelog entries.
+
+### 4. Verify before merging — do not skip
+- `gh pr view <number>` — confirm it's still **OPEN** (not already merged/closed).
+- `gh pr checks <number> --watch` — every check must **pass**. Never merge on a red or pending check.
+
+### 5. Merge
+- `gh pr merge <number> --squash` once checks are green.
+
+### 6. Tag the release — CONFIRM FIRST
+- This triggers the WP.org deploy. **Ask the user to confirm before running it**, even in auto mode — it's an outward-facing production action.
+- `gh release create X.Y.Z --title "X.Y.Z" --notes "<changelog bullets>"`
+- The release notes should match the readme changelog.
+
+### 7. Report
+- Link the release page and note the deploy workflow is running.
+- `git checkout main && git pull` to leave the user on an up-to-date main.
+
+## Guardrails recap
+- Both version files in sync — always.
+- PR still open + all checks green before merge.
+- Explicit confirmation before `gh release create` (prod deploy).
+- Changelog is user-facing language, dated today.


### PR DESCRIPTION
Adds two project skills under `.claude/skills/`:

- **release** — prepare and publish a wp-xeet release: bumps version in both `xeet.php` and `readme.txt`, updates the changelog, opens a release PR, verifies CI, and tags (with confirmation, since the tag triggers the WP.org deploy).
- **pr** — open/check/merge PR lifecycle, with guardrails that work happens on a branch and CI is green before merge.

Both encode the course-corrections from cutting 1.0.4: branch before changes, verify PR open + CI green before merge, confirm before prod-deploying actions.