### PR TITLE
Fix e2e tests for the always-iframed editor in WP 7.1

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ const portMap = Object.fromEntries(
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	retries: 0,
+	retries: process.env.CI ? 1 : 0,
 	workers: 1,
 	reporter: 'html',
 	use: {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Static Posts for Twitter - Embed x.com Tweets without an iframe ===
 Contributors:      kbat82
 Tags:              block, tweet, twitter, social, embed
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        1.0.4
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/block.json
+++ b/src/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "kevinbatdorf/xeet-wp",
 	"version": "0.1.0",
 	"title": "Static Xeets for Twitter",

--- a/tests/xeet-render.spec.ts
+++ b/tests/xeet-render.spec.ts
@@ -6,19 +6,16 @@ test.beforeEach(async ({ requestUtils }) => {
 
 test('Renders a tweet when a valid URL is pasted', async ({
 	admin,
-	page,
 	editor,
 }) => {
 	await admin.createNewPost({ title: 'Render test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
-	// Type a tweet URL into the placeholder input
-	const input = page.getByPlaceholder('Enter URL to embed here...');
+	const input = editor.canvas.getByPlaceholder('Enter URL to embed here...');
 	await input.fill('https://x.com/jack/status/20');
 
-	// Wait for the tweet to render — the NoTweet placeholder disappears
-	// and the xeet data renders inside the block
-	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	// .react-tweet-theme only mounts after the tweet fetch resolves
+	const block = editor.canvas.locator('[data-type="kevinbatdorf/xeet-wp"]');
 	await expect(block.locator('.react-tweet-theme')).toBeVisible({
 		timeout: 30000,
 	});
@@ -29,14 +26,15 @@ test('Renders a tweet when a valid URL is pasted', async ({
 
 test('Shows placeholder when block is inserted without a tweet', async ({
 	admin,
-	page,
 	editor,
 }) => {
 	await admin.createNewPost({ title: 'Empty test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
 	await expect(
-		page.getByLabel('Block: Xeet').getByText('Paste a link to the Xeet URL'),
+		editor.canvas
+			.getByLabel('Block: Xeet')
+			.getByText('Paste a link to the Xeet URL'),
 	).toBeVisible();
 });
 
@@ -65,10 +63,10 @@ test('Block handles missing tweet entity fields without crashing', async ({
 	await admin.createNewPost({ title: 'Missing entities test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
-	const input = page.getByPlaceholder('Enter URL to embed here...');
+	const input = editor.canvas.getByPlaceholder('Enter URL to embed here...');
 	await input.fill('https://x.com/jack/status/20');
 
-	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	const block = editor.canvas.locator('[data-type="kevinbatdorf/xeet-wp"]');
 	await expect(block.locator('.react-tweet-theme')).toBeVisible({
 		timeout: 15000,
 	});
@@ -105,10 +103,10 @@ test('Block renders a tweet that contains a quoted tweet', async ({
 	await admin.createNewPost({ title: 'Quoted tweet test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
-	const input = page.getByPlaceholder('Enter URL to embed here...');
+	const input = editor.canvas.getByPlaceholder('Enter URL to embed here...');
 	await input.fill('https://x.com/jack/status/20');
 
-	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	const block = editor.canvas.locator('[data-type="kevinbatdorf/xeet-wp"]');
 	await expect(block.locator('.react-tweet-theme')).toBeVisible({
 		timeout: 15000,
 	});
@@ -138,31 +136,27 @@ test('Block renders a tweet with an empty media array without crashing', async (
 	await admin.createNewPost({ title: 'Empty media test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
-	const input = page.getByPlaceholder('Enter URL to embed here...');
+	const input = editor.canvas.getByPlaceholder('Enter URL to embed here...');
 	await input.fill('https://x.com/jack/status/20');
 
-	const block = page.locator('[data-type="kevinbatdorf/xeet-wp"]');
+	const block = editor.canvas.locator('[data-type="kevinbatdorf/xeet-wp"]');
 	await expect(block.locator('.react-tweet-theme')).toBeVisible({
 		timeout: 15000,
 	});
 });
 
-test('Invalid input does not clear the field', async ({
-	admin,
-	page,
-	editor,
-}) => {
+test('Invalid input does not clear the field', async ({ admin, editor }) => {
 	await admin.createNewPost({ title: 'Invalid input test' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 
-	const input = page.getByPlaceholder('Enter URL to embed here...');
+	const input = editor.canvas.getByPlaceholder('Enter URL to embed here...');
 	await input.fill('not-a-valid-url');
 
-	// Field should still have the typed value
 	await expect(input).toHaveValue('not-a-valid-url');
 
-	// Block should still show the placeholder, not a tweet
 	await expect(
-		page.getByLabel('Block: Xeet').getByText('Paste a link to the Xeet URL'),
+		editor.canvas
+			.getByLabel('Block: Xeet')
+			.getByText('Paste a link to the Xeet URL'),
 	).toBeVisible();
 });

--- a/tests/xeet.spec.ts
+++ b/tests/xeet.spec.ts
@@ -6,12 +6,11 @@ test.beforeEach(async ({ requestUtils }) => {
 
 test('Plugin is active and block is registered', async ({
 	admin,
-	page,
 	editor,
 }) => {
 	await admin.createNewPost({ title: 'Test post' });
 	await editor.insertBlock({ name: 'kevinbatdorf/xeet-wp' });
 	await expect(
-		page.locator('[data-type="kevinbatdorf/xeet-wp"]'),
+		editor.canvas.locator('[data-type="kevinbatdorf/xeet-wp"]'),
 	).toBeVisible();
 });


### PR DESCRIPTION
Nightly e2e has been red since June 30: WP 7.1 always iframes the post editor (Gutenberg [#74042](https://github.com/WordPress/gutenberg/pull/74042)), so `page.*` locators can't reach the canvas. The block itself renders fine — only the selectors broke.

- Canvas queries: `page.*` → `editor.canvas.*`
- `apiVersion: 2` → `3` — must land together: an apiVersion 2 block forces the non-iframed editor on stable WP, where `editor.canvas` finds nothing
- Retry once in CI only, to absorb WP Playground's random 500s

7/7 pass locally on latest and nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)